### PR TITLE
Major freezing or full lockup while zipping includes output zip file

### DIFF
--- a/marmoset/core/marmosetbrowser.py
+++ b/marmoset/core/marmosetbrowser.py
@@ -434,5 +434,7 @@ def write_zip(name, files):
     """
     with ZipFile(name, 'w') as myzip:
         for f in files:
+            if f == name:
+                continue
             myzip.write(f)
     return name


### PR DESCRIPTION
An issue would occur when you would include the same file your are outputting as zip.
An example of this occurring is running

``` shell
$ marmoset submit course assn *
```

It would pick up the assn.zip, if already submitted once before, and cause a lock up through some recursive CRC check or zipping tomfoolery going on and take a significantly longer time.

This fix just ensures that zip file isn't included as you (hopefully) wouldn't need it in submissions anyways.
