### PR TITLE
Tempfile fix

### DIFF
--- a/marmoset/core/marmosetbrowser.py
+++ b/marmoset/core/marmosetbrowser.py
@@ -50,7 +50,7 @@ class Marmoset():
     @ivar base_url: The base url for the marmoset submission server.
     """
     base_url = "http://marmoset.student.cs.uwaterloo.ca"
-    cookiefile = tempfile.gettempdir() + '/marmoset.session.cookies'
+    cookiefile = os.path.join(tempfile.gettempdir(), 'marmoset.session.cookies')
 
     def __init__(self, username=None, password=None, **kwargs):
         """

--- a/marmoset/core/marmosetbrowser.py
+++ b/marmoset/core/marmosetbrowser.py
@@ -7,6 +7,8 @@ import sys
 import StringIO
 import tempfile
 import os
+
+
 try: 
     from collections import OrderedDict
 except ImportError:

--- a/marmoset/core/marmosetbrowser.py
+++ b/marmoset/core/marmosetbrowser.py
@@ -5,6 +5,8 @@ from anonbrowser import AnonBrowser
 import re
 import sys
 import StringIO
+import tempfile
+import os
 try: 
     from collections import OrderedDict
 except ImportError:
@@ -46,7 +48,7 @@ class Marmoset():
     @ivar base_url: The base url for the marmoset submission server.
     """
     base_url = "http://marmoset.student.cs.uwaterloo.ca"
-    cookiefile = "/tmp/marmoset.session.cookies"
+    cookiefile = tempfile.gettempdir() + '/marmoset.session.cookies'
 
     def __init__(self, username=None, password=None, **kwargs):
         """


### PR DESCRIPTION
I tried using it for Windows but it wouldn't work because it was looking for the harcoded path "/tmp/marmoset.session.cookies". The fix is to use the tempfile module.

Tested it on Ubuntu and OSX and it seems to work fine.