### PR TITLE
fix non-flat zip files

### DIFF
--- a/marmoset/core/marmosetbrowser.py
+++ b/marmoset/core/marmosetbrowser.py
@@ -458,5 +458,5 @@ def write_zip(name, files):
         for f in files:
             if f == name:
                 continue
-            myzip.write(f)
+            myzip.write(f, arcname=os.path.basename(f))
     return name


### PR DESCRIPTION
When adding a file with an absolute or relative path, the zip file will contain the entire directory structure. This fix "flattens" the zip file so that Marmoset doesn't complain, since Marmoset only looks in the top level of the zip file.