### PR TITLE
fix opening zip files in text mode

### DIFF
--- a/marmoset/core/marmosetbrowser.py
+++ b/marmoset/core/marmosetbrowser.py
@@ -194,7 +194,7 @@ class Marmoset():
         else:
             filename = files
 
-        self.browser.form.add_file(open(filename), 'text/plain', filename)
+        self.browser.form.add_file(open(filename, 'rb'), 'application/octet-stream', filename)
         self.browser.submit()
 
         if self.browser.geturl().find("/view/project.jsp?projectPK=") > -1:


### PR DESCRIPTION
All my assignments that needed zipping would "fail to compile" on Marmoset because the zip file wasn't valid--all the Windows newlines in my zip file were getting converted to Unix newlines, because the zip file was being opened in text mode instead of binary mode. This turned it into an invalid zip, according to their tools.

I added application/octet-stream for good measure. Still works for submitting normal source (ie. text) files.
